### PR TITLE
Fix Location prompt on iOS11 (master)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "LLReactNativeTemplateApp",
-  "displayName": "LLReactNativeTemplateApp"
+  "name": "LocalyticsReactTest",
+  "displayName": "LocalyticsReactTest"
 }

--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "LocalyticsReactTest",
-  "displayName": "LocalyticsReactTest"
+  "name": "LLReactNativeTemplateApp",
+  "displayName": "LLReactNativeTemplateApp"
 }

--- a/ios/LocalyticsReactTest/Info.plist
+++ b/ios/LocalyticsReactTest/Info.plist
@@ -46,10 +46,14 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>geofences use location to provide places campaign</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>We just want it!</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Location is used for geofences</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string>Location is used to report campaign triggered location</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "LocalyticsReactTest",
-  "version": "0.0.1",
+  "name": "LLReactNativeTemplateApp",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
Change
TD Ameritrade Escalation.
On iOS11, there was no location prompt.

Test
Load the app and enable location monitoring and check for the prompt.

-- This is PR for master.